### PR TITLE
Fix issue for some versions of the mod_status output (particularly ap…

### DIFF
--- a/apache/apache.py
+++ b/apache/apache.py
@@ -121,7 +121,7 @@ class apache():
             for eachStat in listStatsData:
                 stats = eachStat.split(':')
                 if str(stats[0]) in dict_reqdMet:
-                    self.dictApacheData.setdefault(dict_reqdMet[str(stats[0])], str(stats[1]))
+                    self.dictApacheData.setdefault(dict_reqdMet[str(stats[0])], str.strip(str(stats[1])))
             self.dictApacheData['plugin_version'] = PLUGIN_VERSION
             self.dictApacheData['heartbeat_required'] = HEARTBEAT
             self.dictApacheData['units'] = METRICS_UNITS


### PR DESCRIPTION
Fix issue for some versions of the mod_status output (particularly apache running under cpanel) which contains leading spaces in the values, which in turn was breaking the parsing of the json