### PR TITLE
Fixed JSon error in Elastic 2+, Error handling

### DIFF
--- a/elasticsearchnodes/README.md
+++ b/elasticsearchnodes/README.md
@@ -5,7 +5,7 @@ For monitoring the performance metrics of your Elasticsearch cluster using Site2
   
 ### Author: Anita, Zoho Corp
 ### Language : Python
-### Tested in Ubuntu
+### Tested in Ubuntu, CentOS6
 
 Before you start
 ======================
@@ -31,6 +31,18 @@ Make the following changes in the escluster plugin file ( copied to agent's plug
 Site24x7 agent will now report Elasticsearch cluster statistics in the plugins tab under the site24x7.com portal.
 
 For further monitoring all your Elasticsearch nodes, we suggest adding our linux server monitoring agent in each node.
+
+Configuring for Automated Deploy
+================================
+When using automation, It is common to have Elastic listinging on the LAN IP address and the elastic node name set to the hostname.
+This script contains commented out variables to automatically generate the node name and connection string on the fly.
+
+1. Comment out URL, Username, Password, and Node variables
+
+2. Uncomment IP, URL, Username, Password, and Node variables in the block directly below the ones you commented
+
+3. Deploy using steps outlined above, Restarting monagent when completed. 
+
 
 
 ESCluster Attributes:


### PR DESCRIPTION
Due to changes in Elastic API for versions 2+, The script failed as the CPU metric is in a different location. I removed that entry, Remapped all of the other keys to their new values in Elastic 2+, and added JVM heap % monitoring which is a very useful metric to monitor on.

Also fixed error handling which improperly set any node to a fail state even if it returned the proper information by replacing the else loop in the json parsing if loop to an if loop outside of that which checked to see if the json parsing loop was actually run (and thus a node was matched against the NODENAME variable)

Added functionality to dynamically generate on the fly the connection string and the Node name based off of the LAN IP address and the hostname system variable (to match with Elastic best practice for automated deployments of elasticsearch) These are commented out by default. README updated with instructions for using this functionality if desired. 