### PR TITLE
Fix error 401 on password protected pages

### DIFF
--- a/nginx/nginx.py
+++ b/nginx/nginx.py
@@ -74,7 +74,7 @@ def metricCollector():
         
         url = NGINX_STATUS_URL
         if USERNAME and PASSWORD:
-            password_mgr = urlconnection.HTTPPasswordMgr()
+            password_mgr = urlconnection.HTTPPasswordMgrWithDefaultRealm()
             password_mgr.add_password(None, url, USERNAME, PASSWORD)
             auth_handler = urlconnection.HTTPBasicAuthHandler(password_mgr)
             opener = urlconnection.build_opener(auth_handler)


### PR DESCRIPTION
The issue is, plain and simple, that the credentials appear to never be sent, since a 401 error is returned when trying to access a password protected status page.

At line 77, using HTTPPasswordMgr instead of HTTPPasswordMgrWithDefaultRealm is what causes said issue. According to the docs (https://docs.python.org/3.2/library/urllib.request.html) this has to do with using a realm of None.

The same issue existed for python 2.7.5 and 3.6.8, so I'm guessing that it's not version-specific and that's why I think this change is a must.