### PR TITLE
 file_monitoring.py - fixed the unit of file_size metric

### DIFF
--- a/file_monitoring/file_monitoring.py
+++ b/file_monitoring/file_monitoring.py
@@ -35,7 +35,7 @@ hash_type="md5"
 search_text=""
 case_sensitive="False"
 
-metric_units={"file_size":"kb","time_since_last_accessed":"hours","time_since_last_modified":"hours"}
+metric_units={"file_size":"bytes","time_since_last_accessed":"hours","time_since_last_modified":"hours"}
 
 hash_storage_path = "./hash_value_storage_unit.json"
 


### PR DESCRIPTION
The data gathered from the plugin is in bytes but in the plugin it was wrongly mentioned as kb. So the data was wrongly shown as TB instead of GB. The Issue is fixed by changing the metric into bytes.