### PR TITLE
Fix for empty results

### DIFF
--- a/windows_logon_failures/windows_logon_failures.ps1
+++ b/windows_logon_failures/windows_logon_failures.ps1
@@ -10,7 +10,7 @@ Function Get-Data($count)
 $outdata=@{}
   
 $startTime = (Get-Date).AddMinutes(-5)
-$Events=Get-EventLog -LogName Security -Source "Microsoft-Windows-Security-Auditing" -InstanceId 4625 -EntryType FailureAudit -After $startTime
+$Events=Get-EventLog -LogName Security -Source "Microsoft-Windows-Security-Auditing" -InstanceId 4625 -EntryType FailureAudit -After $startTime -EA silentlycontinue
 $Log=[System.Collections.ArrayList]@()
 $event_count=$Events.Count
 


### PR DESCRIPTION
Fix for situation where Get-EventLog returns empty result set. Previously it ended in error and downed monitor