### PR TITLE
Correctly get security updates count for Ubuntu

### DIFF
--- a/check_updates/check_updates.py
+++ b/check_updates/check_updates.py
@@ -114,14 +114,13 @@ class update_check:
 
                 file_path='/var/lib/update-notifier/updates-available'
                 lines = [line.strip('\n') for line in open(file_path)]
+                self.maindata['Security Updates'] = 0
                 for line in lines:
                     if line:
                         if ( 'packages can be updated' in line ) or ('can be installed immediately' in line ) or ('can be applied immediately' in line):
                             self.maindata['Packages to be Updated'] = line.split()[0]
                         if ('updates are security updates' in line) or ('updates are standard security updates' in line):
                             self.maindata['Security Updates'] = line.split()[0]
-                        else:
-                            self.maindata['Security Updates'] = 0
 
 
             elif os_name=="CentOS Linux":


### PR DESCRIPTION
The previous code would set "Security Updates" to 0 if it finds any line in /var/lib/update-notifier/updates-available after the line containing security updates count.

Sample content of `/var/lib/update-notifier/updates-available`:
```
Expanded Security Maintenance for Applications is not enabled.

11 updates can be applied immediately.
8 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status

```

Each line after `8 of these updates are standard security updates.` would hit the "else" clause and set security updates count to 0