### PR TITLE
postgres: fix bg_stats query on PostgreSQL 17+ (pg_stat_checkpointer)

### DIFF
--- a/postgres/postgres.py
+++ b/postgres/postgres.py
@@ -124,7 +124,12 @@ def inititializeQueries():
     str_MaxConn = "select setting::int max_connections from pg_settings where name=$$max_connections$$;"
     str_dbStats = "SELECT sum(numbackends) as active_connections, sum(xact_commit) as total_commits, sum(xact_rollback) as total_rollbacks, sum(conflicts) as total_conflicts FROM pg_stat_database;"
     str_iostats = "SELECT sum(tup_inserted) as total_rows_inserted, sum(tup_updated) as total_rows_updated ,sum(tup_deleted) as total_rows_deleted, sum(tup_fetched) as total_rows_fetched ,sum(tup_returned) as total_rows_returned,sum(blks_read) as total_block_reads , sum(blks_hit) as total_block_hits FROM pg_stat_database;"
-    str_bgStats = "SELECT checkpoints_timed,checkpoints_req,checkpoint_write_time,checkpoint_sync_time,buffers_checkpoint,buffers_clean,maxwritten_clean,buffers_backend,buffers_backend_fsync,buffers_alloc FROM pg_stat_bgwriter;"
+    if major_version >= 17:
+        # PG17 moved the checkpoint counters to pg_stat_checkpointer; aliased back to
+        # their historical names so reported metric names stay unchanged.
+        str_bgStats = "SELECT c.num_timed AS checkpoints_timed, c.num_requested AS checkpoints_req, c.write_time AS checkpoint_write_time, c.sync_time AS checkpoint_sync_time, c.buffers_written AS buffers_checkpoint, b.buffers_clean, b.maxwritten_clean, b.buffers_alloc FROM pg_stat_checkpointer c, pg_stat_bgwriter b;"
+    else:
+        str_bgStats = "SELECT checkpoints_timed,checkpoints_req,checkpoint_write_time,checkpoint_sync_time,buffers_checkpoint,buffers_clean,maxwritten_clean,buffers_backend,buffers_backend_fsync,buffers_alloc FROM pg_stat_bgwriter;"
     str_idxStats = "SELECT sum(idx_scan) as index_scans,sum(idx_tup_read) as index_rows_read, sum(idx_tup_fetch) as index_rows_fetched FROM pg_stat_user_indexes;"
     str_uptime ="SELECT FLOOR(EXTRACT(EPOCH FROM current_timestamp - pg_postmaster_start_time())) as uptime;"
     str_databaseCount = "SELECT COUNT(*) AS database_count FROM pg_database WHERE datname <> 'template0' AND datname <> 'template1';"


### PR DESCRIPTION
## Problem

`postgres/postgres.py` queries `pg_stat_bgwriter` using the pre-PostgreSQL-17 column
list. PostgreSQL 17 relocated the checkpoint counters into a new `pg_stat_checkpointer`
view and dropped two others, so the `bg_stats` query fails on every collection against
PG 17 or newer:

```
column "checkpoints_timed" does not exist
LINE 1: SELECT checkpoints_timed,checkpoints_req,checkpoint_write_ti...
               ^
```

The failure is caught per-query by the `except` block in `metricCollector()`, which
appends to `self._msg` and rolls back. Collection continues and the monitor still
reports normally, so the breakage is not obvious from the monitor state — only from
the message field and the ten absent metrics:

Checkpoints Timed, Checkpoints Req, Checkpoint Write Time, Checkpoint Sync Time,
Buffers Checkpoint, Buffers Clean, Maxwritten Clean, Buffers Backend,
Buffers Backend Fsync, Buffers Alloc.

Note `buffers_clean`, `maxwritten_clean` and `buffers_alloc` do still exist in PG 17 —
they are lost only as collateral damage, because the whole `SELECT` fails on the first
missing column.

Unlike the activity and session queries in the same function, this query was not
version-gated.

## Column mapping in PostgreSQL 17

| Pre-17 (`pg_stat_bgwriter`) | PostgreSQL 17+ |
|---|---|
| `checkpoints_timed` | `pg_stat_checkpointer.num_timed` |
| `checkpoints_req` | `pg_stat_checkpointer.num_requested` |
| `checkpoint_write_time` | `pg_stat_checkpointer.write_time` |
| `checkpoint_sync_time` | `pg_stat_checkpointer.sync_time` |
| `buffers_checkpoint` | `pg_stat_checkpointer.buffers_written` |
| `buffers_backend` | removed — superseded by `pg_stat_io` |
| `buffers_backend_fsync` | removed — superseded by `pg_stat_io` |

## Change

Gates `str_bgStats` on major version, following the style already used for
`str_usageActiveStat` and `str_Sessions` in the same function. Pre-17 behaviour is
unchanged.

The new columns are aliased back to their historical names, so the metric names the
plugin generates are identical and existing dashboards and thresholds are unaffected.

`major_version` as already computed in `inititializeQueries()` evaluates to `17` for
`server_version` 170010, so no extra parsing was needed.

`buffers_backend` and `buffers_backend_fsync` have no direct equivalent and are
omitted on PG 17+, so those two metrics stop appearing there. They could be
approximated from `pg_stat_io` (`writes` / `fsyncs` for the `client backend` and
`background worker` backend types), but that is a behavioural change rather than a
like-for-like mapping and seemed better left as a separate enhancement — happy to add
it here instead if you would prefer.

## Testing

- Validated against PostgreSQL 17.10 (`PostgreSQL 17.10 on x86_64-pc-linux-gnu`),
  GitLab Omnibus 19.2.0 bundled instance: the new query returns one row with all eight
  columns populated, and the `msg` field is clean.
- Pre-17 branch is byte-identical to the previous query, so PostgreSQL 16 and older are
  unaffected. The same instance ran this plugin correctly on 16.13 before its upgrade.
- `python3 -m py_compile postgres/postgres.py` passes.

You may also want to increment `PLUGIN_VERSION` (currently `1`) so deployed agents pick
up the corrected script.

## Related

The same PostgreSQL 17 change affected comparable projects, for reference:

- prometheus-community/postgres_exporter — issue #1060, fixed in PR #1072
- netdata/netdata — issue #19412
- bitnami/charts — issue #31349
